### PR TITLE
Fixed: Read station names from rrup/statfile in unicode

### DIFF
--- a/visualization/comparisons/psa_ratios_rrup.py
+++ b/visualization/comparisons/psa_ratios_rrup.py
@@ -63,7 +63,7 @@ args = load_args()
 
 # load rrups - station_name,lon,lat,rrup...
 name_rrup = np.loadtxt(
-    args.stats, dtype="|S7,f", usecols=(0, 3), skiprows=1, delimiter=","
+    args.stats, dtype="|U7,f", usecols=(0, 3), skiprows=1, delimiter=","
 )
 
 # load im files (slow) for component, available pSA columns


### PR DESCRIPTION
Issue: Station names read from the statfile/rrup are in bytes type, and the matching with station names from sim/obs ims returned empty array.
Solution: Specified the station names to be read as unicode