### PR TITLE
Replaced os.path with pathlib

### DIFF
--- a/im/spatialise_im.py
+++ b/im/spatialise_im.py
@@ -3,8 +3,8 @@
 Generate non_uniform.xyz and sim/obs.xyz file
 """
 
-import os
 import argparse
+from pathlib import Path
 
 from qcore import shared, utils, constants, formats
 
@@ -19,7 +19,7 @@ def validate_filepath(parser, file_path):
     :param file_path: user input
     :return: parser error if error
     """
-    if os.path.isfile(file_path):
+    if file_path.is_file:
         try:
             with open(file_path, "r") as f:
                 return
@@ -36,7 +36,7 @@ def validate_dir(parser, dir_path):
     :param dir_path: user input
     :return:
     """
-    if not os.path.isdir(dir_path):
+    if not dir_path.is_dir():
         parser.error("No such directory {}".format(dir_path))
 
 
@@ -60,15 +60,15 @@ def write_xyz(imcsv, stat_file, out_dir, component="geom"):
     ims = im_df.columns
     columns = ["lon", "lat", *ims]
 
-    non_uniform_filepath = os.path.join(out_dir, "non_uniform_im.xyz")
-    real_station_filepath = os.path.join(out_dir, "real_station_im.xyz")
+    non_uniform_filepath = out_dir / "non_uniform_im.xyz"
+    real_station_filepath = out_dir / "real_station_im.xyz"
 
     xyz_df[columns].to_csv(non_uniform_filepath, sep=" ", header=None, index=None)
     xyz_real_station_df[columns].to_csv(
         real_station_filepath, sep=" ", header=None, index=None
     )
 
-    im_col_file = os.path.join(out_dir, "im_order.txt")
+    im_col_file = out_dir / "im_order.txt"
     with open(im_col_file, "w") as fp:
         fp.write(" ".join(ims))
 
@@ -77,8 +77,8 @@ def write_xyz(imcsv, stat_file, out_dir, component="geom"):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("imcsv_filepath", help="path to input IMcsv file")
-    parser.add_argument("station_filepath", help="path to input station_ll file path")
+    parser.add_argument("imcsv_filepath", type=Path, help="path to input IMcsv file")
+    parser.add_argument("station_filepath", type=Path, help="path to input station_ll file path")
     parser.add_argument(
         "-c",
         "--component",
@@ -89,7 +89,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-o",
         "--out_dir",
-        default=".",
+        type=Path,
+        default=Path.cwd(),
         help="path to store output xyz files. Defaults to CWD",
     )
 

--- a/im/spatialise_im.py
+++ b/im/spatialise_im.py
@@ -78,7 +78,9 @@ def write_xyz(imcsv, stat_file, out_dir, component="geom"):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("imcsv_filepath", type=Path, help="path to input IMcsv file")
-    parser.add_argument("station_filepath", type=Path, help="path to input station_ll file path")
+    parser.add_argument(
+        "station_filepath", type=Path, help="path to input station_ll file path"
+    )
     parser.add_argument(
         "-c",
         "--component",

--- a/im/spatialise_im.py
+++ b/im/spatialise_im.py
@@ -19,7 +19,7 @@ def validate_filepath(parser, file_path):
     :param file_path: user input
     :return: parser error if error
     """
-    if file_path.is_file:
+    if file_path.is_file():
         try:
             with open(file_path, "r") as f:
                 return


### PR DESCRIPTION
Not essential, but was altered while developing this PR: https://github.com/ucgmsim/slurm_gm_workflow/pull/406

If relative paths were passed to spatialise_im.py from .sl script, it didn't like it. 
This change didn't help the issue (the issue was fixed by adding realpath to im_plot.sl in the other PR), but thought it's good to replace os.path with pathlib anyway.
