### PR TITLE
waveforms.py : Handle if observation data have different timeline per component

### DIFF
--- a/waveform/waveforms.py
+++ b/waveform/waveforms.py
@@ -146,13 +146,10 @@ def plot_station(
                 meta = read_ascii(
                     os.path.join(source, f"{station}{ext}"), meta=True
                 )[1]
-                print(meta)
                 vals = np.array(read_ascii(os.path.join(source, f"{station}{ext}")))
-                print(vals)
                 timeline = (
                     np.arange(meta["nt"], dtype=np.float32) * meta["dt"] + meta["sec"]
                 )
-                print(timeline)
 
                 ts_per_s.append(np.vstack((vals, timeline)))
             timeseries.append(ts_per_s)
@@ -170,7 +167,6 @@ def plot_station(
 
     x_max = max(x_maxes)
 
-    print(x_max)
     if tmax is not None:
         x_max = min(tmax, x_max)
 
@@ -205,7 +201,6 @@ def plot_station(
     plt.xlim([0, x_max])
 
     # subplots
-    print(timeseries)
     for i, s in enumerate(timeseries): #s is each source
         for j in range(len(extensions)):
             ax = axis[j]
@@ -270,8 +265,6 @@ if __name__ == "__main__":
 
     # binary class object or text folder location
     sources = [load_location(source[0], args.v) for source in args.waveforms]
-
-    print(sources)
 
     # station list
     stations = intersection([load_stations(source) for source in sources])

--- a/waveform/waveforms.py
+++ b/waveform/waveforms.py
@@ -151,7 +151,8 @@ def plot_station(output, sources, labels, tmax, verbose, station):
 
     x_max = -float(
         "inf"
-    )  # find maximum time for all components and sources to determine plotting range
+    )  # to find the maximum time for all components and sources to determine plotting range
+
     same_comp_vals = dict.fromkeys(
         components, np.empty(0)
     )  # a container to store all vals from the same component
@@ -167,18 +168,18 @@ def plot_station(output, sources, labels, tmax, verbose, station):
             )  # vals from all sources for the same components are grouped together
 
     if tmax is not None:
-        x_max = min(tmax, x_max)  # if user specified the maximum time, use it insteads
+        x_max = min(tmax, x_max)  # if user specified the maximum time, use it instead
 
     # find maximum/minimum values for each component (from all sources) to determine plotting range
     ppgvs = {}
     npgvs = {}
     pgvs = {}
-    for comp in components:  # vals from all sources for the same components
+    for comp in components:
         ppgvs[comp] = np.max(same_comp_vals[comp])
         npgvs[comp] = np.min(same_comp_vals[comp])
         pgvs[comp] = np.max(np.abs(same_comp_vals[comp]))
-    y_min = np.min(list(npgvs.values()))
-    y_max = np.max(list(ppgvs.values()))
+    y_min = np.min(list(npgvs.values()))  # minimum value for all components and sources
+    y_max = np.max(list(ppgvs.values()))  # maximum value for all components and sources
     y_diff = y_max - y_min
 
     scale_length = max(int(round(x_max / 25.0)) * 5, 5)

--- a/waveform/waveforms.py
+++ b/waveform/waveforms.py
@@ -114,7 +114,7 @@ def load_stations(source):
     return stations
 
 
-def plot_station(output, sources, labels, tmax, verbose, align, station):
+def plot_station(output, sources, labels, tmax, verbose, station):
     """Creates a waveform plot for a specific station."""
 
     if verbose:
@@ -281,6 +281,5 @@ if __name__ == "__main__":
         [source[1] for source in args.waveforms],
         args.tmax,
         args.v,
-        args.align,
     )
     p.map(single_station, stations)

--- a/waveform/waveforms.py
+++ b/waveform/waveforms.py
@@ -252,7 +252,7 @@ def plot_station(output, sources, labels, tmax, verbose, station):
 
             if i == 0:
                 # Add component label
-                ax.set_title(components[j][1:], fontsize=18)
+                ax.set_title(components[j], fontsize=18)
                 ax.text(x_max, y_max, "{:.1f}".format(pgvs[comp]), fontsize=14)
 
     plt.savefig(os.path.join(output, f"{station}.png"))

--- a/waveform/waveforms.py
+++ b/waveform/waveforms.py
@@ -252,7 +252,7 @@ def plot_station(output, sources, labels, tmax, verbose, station):
 
             if i == 0:
                 # Add component label
-                ax.set_title(components[j], fontsize=18)
+                ax.set_title(comp, fontsize=18)
                 ax.text(x_max, y_max, "{:.1f}".format(pgvs[comp]), fontsize=14)
 
     plt.savefig(os.path.join(output, f"{station}.png"))

--- a/waveform/waveforms.py
+++ b/waveform/waveforms.py
@@ -19,7 +19,6 @@ from visualization.util import intersection
 
 # files that contain the 3 components (text based)
 components = [".090", ".000", ".ver"]
-# components = [".090", ".000"]
 
 BINARY_FORMATS = {"BB": BBSeis, "LF": LFSeis, "HF": HFSeis}
 colours = ["black", "red", "blue", "magenta", "darkgreen", "orange"]
@@ -230,7 +229,7 @@ def plot_station(output, sources, labels, tmax, verbose, align, station):
     plt.xlim([0, x_max])
 
     # subplots
-    for i, ts_pair_dict in enumerate(timeseries):  # s is each source
+    for i, ts_pair_dict in enumerate(timeseries):
         for j, comp in enumerate(components):
             ax = axis[j]
             ax.set_axis_off()

--- a/waveform/waveforms.py
+++ b/waveform/waveforms.py
@@ -167,7 +167,6 @@ def plot_station(output, sources, labels, tmax, verbose, station):
                 [vals_from_same_comp[j], vals]
             )  # group vals from the same components together
 
-
     if tmax is not None:
         x_max = min(tmax, x_max)
 


### PR DESCRIPTION
(Not scoped for this sprint - but did it over the weekend while helping Seokho's Korean data)

This is a fix for a case when observation data has different timeline per component - currently all components are assumed to have the same timeline (starting at the same time), which was not the case with observation data from Korea - In fact, we can't really assume the integrity of observation data.

Also added an "align" option when the simulation data and observation (or any timeseries data we are comparing) don't have the compatible timeline (eg. observation starts at 53sec, simulation starts at -1sec) - I chose to to align the peak of amplitude

Without align
![YOCB](https://user-images.githubusercontent.com/466989/136864715-3fff045a-65d1-4896-9b29-1bd36ae893fa.png)

With align
![YOCB](https://user-images.githubusercontent.com/466989/136864800-cea6157e-0d01-4341-87de-5e3d52f28c0c.png)

