### PR TITLE
Fixed an issue discovered while testing plot_srf workflow step

### DIFF
--- a/sources/plot_srf_map.py
+++ b/sources/plot_srf_map.py
@@ -27,6 +27,7 @@ def get_args():
     arg("--cpt", help="CPT for SRF slip", default=gmt.CPTS["slip"])
     arg("--depth", help="also make a depth only plot", action="store_true")
     arg("--downscale", help="render resolution multiplier", type=int, default=4)
+    arg("--outdir", help="output directory")
 
     args = parser.parse_args()
     args.srf_file = os.path.abspath(args.srf_file)
@@ -38,9 +39,12 @@ def get_args():
 
 faults = "/nesi/project/nesi00213/PlottingData/Paths/faults/FAULTS_20161219.ll"
 
+
 args = get_args()
 # output directory for srf resources
 gmt_tmp = os.path.abspath(mkdtemp())
+if not args.outdir:
+    outdir=os.path.dirname(os.path.abspath(args.srf_file)) #default outdir is the same directory as SRF
 
 # whether we are plotting a finite fault or point source
 finite_fault = srf.is_ff(args.srf_file)
@@ -639,6 +643,6 @@ p.png(
     dpi=args.dpi * args.downscale,
     downscale=args.downscale,
     background="white",
-    out_dir=".",
+    out_dir=outdir,
 )
 rmtree(gmt_tmp)

--- a/sources/plot_srf_slip_rise_rake.py
+++ b/sources/plot_srf_slip_rise_rake.py
@@ -32,8 +32,6 @@ if args.out_dir is None:
 if args.out_dir == "":
     args.out_dir = "."
 os.makedirs(args.out_dir, exist_ok=True)
-if not os.path.isdir(args.out_dir):
-    os.makedirs(args.out_dir)
 
 gmt_temp = mkdtemp(prefix="_GMT_WD_SRF_")
 

--- a/sources/plot_srf_slip_rise_rake.py
+++ b/sources/plot_srf_slip_rise_rake.py
@@ -31,6 +31,7 @@ if args.out_dir is None:
     args.out_dir = os.path.dirname(args.srf_file)
 if args.out_dir == "":
     args.out_dir = "."
+os.makedirs(args.out_dir, exist_ok=True)
 if not os.path.isdir(args.out_dir):
     os.makedirs(args.out_dir)
 


### PR DESCRIPTION
1. It is weird. 
```
Traceback (most recent call last):
  File "/nesi/project/nesi00213/Environments/bae_py36/visualization/sources/plot_srf_slip_rise_rake.py", line 35, in <module>
    os.makedirs(args.out_dir)
  File "/opt/nesi/mahuika/Python/3.6.3-gimkl-2017a/lib/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/scale_wlg_nobackup/filesets/nobackup/nesi00213/RunFolder/EndToEndTest/tests/tmp_20211208_020617/Data/Sources/Hossack/verification'
```
mkdir is called if no such directory exists - It seems it is called regardless and I was getting this error. Well, `exist_ok=True` is more elegant anyway.

2. According to plot_srf.sl, 
```
    # output map plot is defaultly saved to srf folder, move it to Verification folder
    if [[ -f "$STATIC_OUTPUT_MAP_PLOT_PATH" ]]; then
        echo "outputted plots to $OUTPUT_DIR"
        mv "$STATIC_OUTPUT_MAP_PLOT_PATH" "$OUTPUT_DIR"
    fi
```
srf map is by default placed under Srf directory, which wasn't true. It is saved at "." by default, which is most likely to be Cybershake root directory. Fixed here. plot_srf.sl is no longer lying.

